### PR TITLE
Added is_staff field on user create page

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -14,7 +14,7 @@ class CustomUserAdmin(UserAdmin):
     add_fieldsets = (
         (None, {
             'classes': ('wide',),
-            'fields': ('username', 'email', 'password1', 'password2', 'role'),
+            'fields': ('username', 'email', 'password1', 'password2', 'role', 'is_staff'),
         }),
     )
     list_display = ('username', 'email', 'role', 'is_staff')


### PR DESCRIPTION
b4 change, got error that cinema manager acc is created with is_staff : false.
after this, when creating account (manager), admin and superuser can tick is_staff 